### PR TITLE
Dropping Ubuntu in favour of Alpine

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:24.04
+FROM alpine:latest
 
 ENV DB_HOST="db"
 ENV DB_PORT="3306"
@@ -11,16 +11,14 @@ ENV S3_PATH=""
 ENV DUMP_PREFIX=""
 
 # Install dependencies
-RUN apt update && \
-    apt upgrade -y && \
-    apt install -y \
+RUN apk update && \
+    apk upgrade --available && \
+    apk add --no-cache \
         ca-certificates \
         mariadb-client \
         postgresql-client \
         gzip \
-        rclone && \
-    apt clean && \
-    rm -rf /var/lib/apt/lists/*
+        rclone
 
 WORKDIR /data
 

--- a/build/entrypoint.sh
+++ b/build/entrypoint.sh
@@ -2,7 +2,7 @@
 
 # === Internal variables ===
 DATE_STR=$(date +"%Y-%m-%d_%H-%M-%S")
-FILENAME="${DUMP_PREFIX}-${DATE_STR}.sql.gz"
+FILENAME="${DUMP_PREFIX}_${DATE_STR}.sql.gz"
 DUMP_PATH="/data/${FILENAME}"
 
 # === Function to dump database(s) ===


### PR DESCRIPTION
This PR modifies the base image to Alpine, to save some space and get newer releases of rclone on the fly.